### PR TITLE
Support the DSOX2004A 4-channel Oscilloscope

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ Development Lead
 Contributors
 ============
 
+* Tom Nellius
 * Kevin Koch
 * Bruno Mecke
 * Hanna Schmiegel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,15 @@ This project follows the guidelines of `Keep a changelog`_ and adheres to
 .. _Semantic versioning: https://semver.org/
 
 
+`0.1.1`_ - 2024-09-24
+=====================
+
+Added
+-----
+* Suppport for DSOX2004A
+* General support for 4-channel oscilloscopes
+
+
 `0.1.0`_ - 2022-12-01
 =====================
 
@@ -19,3 +28,4 @@ Added
 
 .. _Unreleased: https://github.com/emtpb/keysightosc
 .. _0.1.0: https://github.com/emtpb/keysightosc/releases/tag/0.1.0
+.. _0.1.1: https://github.com/emtpb/keysightosc/releases/tag/0.1.1

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Interface for Keysight Oscilloscopes.
 Features
 ========
 
-* Basic support for model DSOX1102A
+* Basic support for model DSOX1102A and DSOX2004A
 
 
 Installation

--- a/keysightosc/oscilloscope.py
+++ b/keysightosc/oscilloscope.py
@@ -121,7 +121,7 @@ class Oscilloscope:
         # Increase timeout to 10 seconds for transfer of long signals.
         self.visa_timeout = 10
 
-        self.channels = [Channel(self, 1), Channel(self, 2)]
+        self.channels = [Channel(self, 1), Channel(self, 2), Channel(self, 3), Channel(self, 4)]
 
     def _clear(self):
         """
@@ -226,7 +226,12 @@ class Oscilloscope:
         self._write('*RST')
         self.channels[0].attenuation = 1
         self.channels[1].attenuation = 1
-
+        try:
+            self.channels[2].attenuation = 1
+            self.channels[3].attenuation = 1
+        except RuntimeError:
+            pass
+        
     def run(self):
         """Start data acquisition."""
         self._write(':RUN')
@@ -615,8 +620,7 @@ class Oscilloscope:
         """Set the source of the FFT.
 
         Args:
-            source (int): Source of the FFT. Either 1 for CHANnel1 or 2 for
-                          CHANnel2.
+            source (int): Source of the FFT. Can be any channel
         """
         self._write(":FFT:SOURce1 CHANnel{}".format(source))
 
@@ -791,7 +795,7 @@ class Oscilloscope:
     def get_math_function_source(self, source):
         """Get a function source. There are two sources
         (source 1 and source 2). These sources are used for the
-        math_functions and can be either channel 1 or channel 2.
+        math_functions and can be any channel.
 
         Args:
             source(int): Source to get.
@@ -800,8 +804,8 @@ class Oscilloscope:
 
     def set_math_function_source(self, source, channel):
         """Set a math source. There are two sources (source 1 and source 2).
-        These sources are used for the math_functions and can be channel 1 or
-        channel 2. The math_functions 'ADD', 'SUBT', 'MULT' and 'DIV' use
+        These sources are used for the math_functions and can any channel.
+        The math_functions 'ADD', 'SUBT', 'MULT' and 'DIV' use
         source 1 and source 2. The math_functions 'FFT', 'FFTPhase', and
         'LOWPass' use only source 1.
 

--- a/tests/test_oscilloscope.py
+++ b/tests/test_oscilloscope.py
@@ -1,4 +1,0 @@
-"""Tests for `keysightosc` package."""
-import pytest
-
-from keysightosc import oscilloscope


### PR DESCRIPTION
A bit of refactoring was done to make adding new models in the future easier. Also it is now assumed that a connected oscilloscope can have 4 channels. When trying to access a third or fourth channel on a 2-channel oscilloscope, `RuntimeError: Instrument error: Hardware missing.` error is thrown.
